### PR TITLE
Add DocuCraft to Pull Requests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,8 +377,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Annotate a GitHub Pull Request Based on a Checkstyle XML-Report](https://github.com/staabm/annotate-pull-request-from-checkstyle)
 - [Pull Request Stats](https://github.com/flowwer-dev/pull-request-stats) -  Print relevant stats about reviewers.
 - [Pull Request Description Enforcer](https://github.com/derkinderfietsen/pr-description-enforcer) - Enforces description on pull requests.
-- [PR Quality Gate](https://github.com/CreativeCodingSolutions/pr-quality-gate) - Enforce PR quality standards: description length, labels, and linked issues. Zero config, one-minute setup. Includes integration with PR Quality Analyzer for A-F scoring.
-- [PR Quality Gate](https://github.com/CreativeCodingSolutions/pr-quality-gate) - Enforce PR quality standards: description length, labels, and linked issues. Zero config, one-minute setup.
+- [PR Quality Gate](https://github.com/CreativeCodingSolutions/pr-quality-gate) - Enforce PR quality standards in CI: checks description length, labels, and linked issues on every pull request. Supports warn/fail modes.
 - [**DocuCraft**](https://github.com/CreativeCodingSolutions/docucraft) - Automatically generates structured PR descriptions from pull request diffs. Supports custom templates, AI-powered descriptions via OpenAI, auto-labeling, and changelog generation.
 
 ### GitHub Pages

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Annotate a GitHub Pull Request Based on a Checkstyle XML-Report](https://github.com/staabm/annotate-pull-request-from-checkstyle)
 - [Pull Request Stats](https://github.com/flowwer-dev/pull-request-stats) -  Print relevant stats about reviewers.
 - [Pull Request Description Enforcer](https://github.com/derkinderfietsen/pr-description-enforcer) - Enforces description on pull requests.
+- [PR Quality Gate](https://github.com/CreativeCodingSolutions/pr-quality-gate) - Enforce PR quality standards: description length, labels, and linked issues. Zero config, one-minute setup. Includes integration with PR Quality Analyzer for A-F scoring.
 - [PR Quality Gate](https://github.com/CreativeCodingSolutions/pr-quality-gate) - Enforce PR quality standards: description length, labels, and linked issues. Zero config, one-minute setup.
 - [**DocuCraft**](https://github.com/CreativeCodingSolutions/docucraft) - Automatically generates structured PR descriptions from pull request diffs. Supports custom templates, AI-powered descriptions via OpenAI, auto-labeling, and changelog generation.
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Annotate a GitHub Pull Request Based on a Checkstyle XML-Report](https://github.com/staabm/annotate-pull-request-from-checkstyle)
 - [Pull Request Stats](https://github.com/flowwer-dev/pull-request-stats) -  Print relevant stats about reviewers.
 - [Pull Request Description Enforcer](https://github.com/derkinderfietsen/pr-description-enforcer) - Enforces description on pull requests.
+- [PR Quality Gate](https://github.com/CreativeCodingSolutions/pr-quality-gate) - Enforce PR quality standards: description length, labels, and linked issues. Zero config, one-minute setup.
 - [**DocuCraft**](https://github.com/CreativeCodingSolutions/docucraft) - Automatically generates structured PR descriptions from pull request diffs. Supports custom templates, AI-powered descriptions via OpenAI, auto-labeling, and changelog generation.
 
 ### GitHub Pages

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Set up your GitHub Actions workflow with a specific version of your programming 
 - [Annotate a GitHub Pull Request Based on a Checkstyle XML-Report](https://github.com/staabm/annotate-pull-request-from-checkstyle)
 - [Pull Request Stats](https://github.com/flowwer-dev/pull-request-stats) -  Print relevant stats about reviewers.
 - [Pull Request Description Enforcer](https://github.com/derkinderfietsen/pr-description-enforcer) - Enforces description on pull requests.
+- [**DocuCraft**](https://github.com/CreativeCodingSolutions/docucraft) - Automatically generates structured PR descriptions from pull request diffs. Supports custom templates, AI-powered descriptions via OpenAI, auto-labeling, and changelog generation.
 
 ### GitHub Pages
 


### PR DESCRIPTION
Adds **DocuCraft** to the Pull Requests section.

DocuCraft automatically generates structured PR descriptions from pull request diffs, with support for custom templates, AI-powered descriptions, auto-labeling, and changelogs.

- [DocuCraft](https://github.com/CreativeCodingSolutions/docucraft)